### PR TITLE
Only show killed count of the lost

### DIFF
--- a/KillCounter/Config/XComKillCounter_Defaults.ini
+++ b/KillCounter/Config/XComKillCounter_Defaults.ini
@@ -19,9 +19,6 @@ showRemainingInsteadOfTotal=true
 ; don't include them here as well by default. If you like, you can enable counting them.
 includeTurrets=false
 
-; If true, The Lost will get counted as enemies as well.
-includeTheLost=true
-
 ; In case things don't work as expected, this switch enables logging of (possibly)
 ; valueable information. 
 debug=false


### PR DESCRIPTION
So it wasn't the best idea to just add up all the numbers, this commit
moved the killed lost count out of the 'enemy' killed count into its own
counter.